### PR TITLE
lock django to < 1.8.0 until django-configurations support django-1.8.0+

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # Bleeding edge Django
-django>=1.7.1
+django>=1.7.1,<1.8.0
 
 # Configuration
 django-configurations==0.8


### PR DESCRIPTION
Lock django in requirements.txt to <1.8.x as django-configurations is not yet compatible with 1.8.x.

See https://github.com/jezdez/django-configurations/issues/111 for details. 
